### PR TITLE
Fix: Auto-regenerate index.md in release workflow

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -56,6 +56,19 @@ jobs:
             echo "tag_exists=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Regenerate index.md from resume.md
+        if: steps.check_tag.outputs.tag_exists == 'false'
+        run: |
+          # Regenerate index.md with frontmatter from resume.md
+          cat > index.md <<'INDEXEOF'
+---
+layout: default
+title: "Brian J. Murray - Resume"
+---
+
+INDEXEOF
+          cat resume.md >> index.md
+
       - name: Create release
         if: steps.check_tag.outputs.tag_exists == 'false'
         id: release
@@ -91,3 +104,14 @@ jobs:
             -H "Content-Type: application/octet-stream" \
             --data-binary @resume.pdf \
             "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=resume.pdf"
+
+      - name: Commit regenerated index.md to main
+        if: steps.release.outputs.created == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add index.md
+          git commit -m "Auto-regenerate index.md from resume.md for v${{ steps.version.outputs.next_version }}" || echo "No changes to commit"
+          git push origin main || echo "Push failed (may already be up to date)"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem
Auto-release workflow was creating releases and PDFs, but NOT updating index.md on the website. This caused the website to show stale content while PDFs had latest updates.

## Solution
Updated auto_release.yml to:
1. Regenerate index.md from resume.md (before release)
2. Create release + generate PDF
3. Commit regenerated index.md back to main
4. This triggers GitHub Pages to rebuild with latest content

## Result
Now when resume.md changes:
- Website updates automatically
- PDF generated with latest changes
- Both stay in sync