### PR TITLE
UX: Hide QR codes on website, keep in PDF

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,8 @@
       body { font-family: Arial, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; line-height:1.4; color:#111 }
       h1,h2,h3,h4 { color:#1a1a1a }
       a { color:#0366d6 }
+      /* Hide QR codes on website (visible in PDF) */
+      img[src*="qr.png"] { display: none; }
     </style>
   </head>
   <body>


### PR DESCRIPTION
QR codes are useful in PDF for scanning but clutter the webpage. CSS now hides them on the website while keeping them in the generated PDF.