### PR TITLE
Fix: Remove YAML frontmatter from website display

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -67,7 +67,8 @@ jobs:
           ---
 
           EOF
-          cat resume.md >> index.md
+          # Skip the first 8 lines (YAML frontmatter) and append resume content
+          tail -n +9 resume.md >> index.md
 
       - name: Create release
         if: steps.check_tag.outputs.tag_exists == 'false'

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,14 +6,10 @@
     <title>{{ page.title }}</title>
     <style>
       body { font-family: Arial, sans-serif; max-width: 800px; margin: 2rem auto; padding: 0 1rem; line-height:1.4; color:#111 }
-      h1 { display: none; }
-      h2,h3,h4 { color:#1a1a1a }
+      h1,h2,h3,h4 { color:#1a1a1a }
       a { color:#0366d6 }
       /* Hide QR codes and pandoc width syntax on website (visible in PDF) */
       img[src*="qr.png"] { display: none; }
-      img[src*="qr.png"] + em { display: none; }
-      /* Remove pandoc width attribute text from HTML */
-      em:contains("{width") { display: none; }
     </style>
     <script>
       // Remove pandoc width syntax from HTML on page load


### PR DESCRIPTION
- Strip resume.md YAML frontmatter when regenerating index.md (skip first 8 lines)
- Restore h1 'BRIAN J. MURRAY' header on website
- Keep YAML frontmatter in resume.md for PDF generation