### PR TITLE
Fix: Add explicit dimensions to QR code images for better PDF rendering

### DIFF
--- a/resume.md
+++ b/resume.md
@@ -9,7 +9,7 @@ titlepage: false
 
 # BRIAN J. MURRAY
 
-brian@cfktech.com · ![](linkedin-qr.png) LinkedIn: https://www.linkedin.com/in/brianjmurray/
+brian@cfktech.com · ![LinkedIn QR Code](linkedin-qr.png){width=2cm height=2cm} LinkedIn: https://www.linkedin.com/in/brianjmurray/
 
 ## PROFESSIONAL EXPERIENCE
 
@@ -65,7 +65,7 @@ brian@cfktech.com · ![](linkedin-qr.png) LinkedIn: https://www.linkedin.com/in/
 
 ## CERTIFICATIONS
 
-![](databricks-qr.png) **Databricks Data Engineer Associate** (June 2025)
+![Databricks QR Code](databricks-qr.png){width=2cm height=2cm} **Databricks Data Engineer Associate** (June 2025)
 
 ## EDUCATION
 


### PR DESCRIPTION
QR codes weren't displaying in PDF due to missing dimensions. Adding explicit width/height using pandoc syntax.