### PR TITLE
BUG FIX: Replace fragile grep/awk JSON parsing with jq in auto_release workflow - fixes #38

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -82,14 +82,21 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Get release ID from tag
+          # Get release ID from tag (using jq for reliable JSON parsing)
           RELEASE_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
             "https://api.github.com/repos/${{ github.repository }}/releases/tags/${{ steps.version.outputs.next_version }}" \
-            | grep '"id"' | head -1 | awk '{print $2}' | tr -d ',')
+            | jq -r '.id')
+          
+          if [ -z "$RELEASE_ID" ] || [ "$RELEASE_ID" = "null" ]; then
+            echo "ERROR: Could not get release ID from API response"
+            exit 1
+          fi
+          
+          echo "Uploading PDF to release ID: $RELEASE_ID"
           
           # Upload asset via REST API
           curl -X POST \
             -H "Authorization: token $GITHUB_TOKEN" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @resume.pdf \
-https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=resume.pdf
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}/assets?name=resume.pdf"


### PR DESCRIPTION
Changes:
- Replace grep | awk | tr -d with jq -r '.id' for reliable JSON parsing
- Add error handling: exit if RELEASE_ID is null or empty
- Fix URL formatting (was broken across lines)
- Add debug output showing RELEASE_ID

This fixes the silent failures that prevented v1.0.16 from being created
