### PR TITLE
Enhancement: Add index.md to auto-release trigger paths

### DIFF
--- a/.github/workflows/auto_release.yml
+++ b/.github/workflows/auto_release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - index.md
       - resume.md
       - _layouts/**
       - _config.yml


### PR DESCRIPTION
index.md (homepage) changes should trigger a release so that homepage updates are versioned and tracked.
Previous: index.md was not in trigger paths, so homepage fixes didn't create releases.
Now: homepage, resume, blog, and projects all trigger releases.
