### PR TITLE
Add project cards for brew-setup-and-update and cfktech-resume - closes #26, closes #27

### DIFF
--- a/projects/index.md
+++ b/projects/index.md
@@ -22,4 +22,34 @@ permalink: /projects/
       <a href="/blog/sql-server-database-projects-template" class="project-link">Read Blog Post</a>
     </div>
   </article>
+
+  <article class="project-card">
+    <h2>Homebrew Automation & macOS Updates</h2>
+    <p class="project-description">Bash automation for simplifying macOS package management with Homebrew. Includes initial setup, regular updates, and multi-Mac synchronization strategies.</p>
+    <div class="project-meta">
+      <span class="tech-tag">Bash</span>
+      <span class="tech-tag">macOS</span>
+      <span class="tech-tag">Automation</span>
+      <span class="tech-tag">DevOps</span>
+    </div>
+    <div class="project-links">
+      <a href="https://github.com/brianjmurray/brew-setup-and-update" class="project-link">View Repository</a>
+      <a href="/blog/homebrew-automation-macos-updates" class="project-link">Read Blog Post</a>
+    </div>
+  </article>
+
+  <article class="project-card">
+    <h2>cfktech.com Portfolio Site</h2>
+    <p class="project-description">A modern portfolio and blog built with Jekyll and GitHub Pages, featuring automated CI/CD workflows, PDF resume generation, and a scalable blog infrastructure.</p>
+    <div class="project-meta">
+      <span class="tech-tag">Jekyll</span>
+      <span class="tech-tag">GitHub Pages</span>
+      <span class="tech-tag">GitHub Actions</span>
+      <span class="tech-tag">CI/CD</span>
+    </div>
+    <div class="project-links">
+      <a href="https://github.com/brianjmurray/cfktech-resume" class="project-link">View Repository</a>
+      <a href="/blog/cfktech-portfolio-site" class="project-link">Read Blog Post</a>
+    </div>
+  </article>
 </div>


### PR DESCRIPTION
Adds two new project showcase cards to the projects page:

- **brew-setup-and-update**: Homebrew automation for macOS package management
- **cfktech-resume**: This portfolio site itself

Both cards link to their respective GitHub repositories and blog posts. All three projects are now featured on the projects page.