### PR TITLE
Enable RSS feed for Medium cross-posting - fixes #52

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,10 @@ title: "Brian J. Murray - Resume"
 baseurl: ""
 url: "https://cfktech.com"
 
+# Plugins
+plugins:
+  - jekyll-feed
+
 # Collections for blog posts
 collections:
   posts:


### PR DESCRIPTION
Enables jekyll-feed plugin to generate feed.xml for syndicating posts to Medium.

This enables Phase 3b: RSS + Manual Medium Cross-Posting workflow.

- Adds jekyll-feed to _config.yml plugins
- feed.xml will auto-generate on deploy
- Feed available at https://cfktech.com/feed.xml