### PR TITLE
Fix tag name mismatches between posts and tag pages - fixes #62

### DIFF
--- a/blog/tags/github-pages.md
+++ b/blog/tags/github-pages.md
@@ -1,5 +1,5 @@
 ---
 layout: tag
-tag: GitHubPages
+tag: GitHub Pages
 permalink: /blog/tags/github-pages/
 ---

--- a/blog/tags/phase1.md
+++ b/blog/tags/phase1.md
@@ -1,5 +1,5 @@
 ---
 layout: tag
-tag: Phase1
+tag: Phase 1
 permalink: /blog/tags/phase1/
 ---

--- a/blog/tags/product-planning.md
+++ b/blog/tags/product-planning.md
@@ -1,5 +1,5 @@
 ---
 layout: tag
-tag: ProductPlanning
+tag: Product Planning
 permalink: /blog/tags/product-planning/
 ---

--- a/blog/tags/sql-server.md
+++ b/blog/tags/sql-server.md
@@ -1,5 +1,5 @@
 ---
 layout: tag
-tag: SQLServer
+tag: SQL Server
 permalink: /blog/tags/sql-server/
 ---


### PR DESCRIPTION
Updates tag page definitions to match the exact tag names used in blog posts.

Changes:
- phase1.md: 'Phase1' → 'Phase 1'
- sql-server.md: 'SQLServer' → 'SQL Server'
- github-pages.md: 'GitHubPages' → 'GitHub Pages'
- product-planning.md: 'ProductPlanning' → 'Product Planning'

This fixes tag pages not displaying posts due to case/spacing mismatches.