### PR TITLE
Fix phase1 tag permalink mismatch - fixes #62 (properly this time)

### DIFF
--- a/blog/tags/phase1.md
+++ b/blog/tags/phase1.md
@@ -1,5 +1,5 @@
 ---
 layout: tag
 tag: Phase 1
-permalink: /blog/tags/phase1/
+permalink: /blog/tags/phase-1/
 ---


### PR DESCRIPTION
Fixes the phase1 tag page permalink to match Jekyll's auto-generated links.

**Problem**: Tag page had permalink: /blog/tags/phase1/ but Jekyll generates links to /blog/tags/phase-1/ (with hyphen)

**Solution**: Change permalink from phase1 to phase-1

**Testing**: This PR should be tested on staging before merge to verify the tag page displays Phase 1 posts correctly.