### PR TITLE
Add Google Analytics 4 tracking - fixes #31

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ page.title }}</title>
+    
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-9QGHXPKHHS"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', 'G-9QGHXPKHHS');
+    </script>
+    
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       


### PR DESCRIPTION
## Summary

Added Google Analytics 4 to track site engagement and understand reader behavior.

## Changes

- Added GA4 tracking script to `_layouts/default.html`
- Measurement ID: `G-9QGHXPKHHS`
- Tracks all pages automatically

## What GA4 Will Track

- Page views by section (blog, projects, resume, homepage)
- Popular blog posts
- Traffic sources (Google, social media, direct)
- Reader geography
- Time spent on pages
- User flow through site

## Verification

After merge, verify in GA4:
1. Visit https://analytics.google.com/
2. Go to Reports → Realtime
3. Open https://cfktech.com in another tab
4. You should see yourself as an active user

Data starts appearing within 24-48 hours for historical reports.
